### PR TITLE
[#14] basic function of verify email

### DIFF
--- a/daimaduan/bootstrap.py
+++ b/daimaduan/bootstrap.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import os
 import bottle
-import logging
 import mongoengine
 
 from bottle_login import LoginPlugin
@@ -11,10 +10,7 @@ from rauth import OAuth2Service
 
 app = bottle.default_app()
 
-# Setup logger
-logging.basicConfig(format='%(levelname)s %(asctime)s %(message)s', level=logging.INFO)
-logger = logging.getLogger('daimaduan')
-
+# Auto cast `site.debug` to boolean type.
 app.config.load_config('config.cfg')
 # Check if there's a key in env variables
 # if you want to set config on the fly, use env var

--- a/daimaduan/config.cfg.sample
+++ b/daimaduan/config.cfg.sample
@@ -5,7 +5,9 @@ database = daimaduan
 [site]
 debug = true
 validate_key = "youdon'tneedtoknow"
+secret_key = "ddf4FP4U&VydAq"
 disqus = daimaduan-dev
+token_salt = "iamDavid"
 
 [oauth.google]
 name = google
@@ -26,3 +28,9 @@ access_token_url = https://github.com/login/oauth/access_token
 base_url = https://api.github.com/
 callback_url = http://daimaduan.dev:8080/oauth/github/callback
 scope = user:email
+
+[mail]
+username = daimaduan
+password = guessme
+host = smtp.gmail.com
+port = 587

--- a/daimaduan/models.py
+++ b/daimaduan/models.py
@@ -22,6 +22,8 @@ class User(BaseDocument):
     password = mongoengine.StringField(required=True)
     salt = mongoengine.StringField()
     favourites = mongoengine.ListField(mongoengine.ReferenceField("Paste"))
+    is_email_confirmed = mongoengine.BooleanField(default=False)
+    email_confirmed_on = mongoengine.DateTimeField(default=None)
 
     oauths = mongoengine.ListField(mongoengine.ReferenceField('UserOauth'))
 

--- a/daimaduan/templates/email/active.html
+++ b/daimaduan/templates/email/active.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+{% if email %}
+    <span>
+        恭喜您, 注册成功! 我们已经向您的注册邮箱发送了激活邮件, 请检查并激活您的账户.
+    </span>
+    <br>
+    <span>
+        如果您没有收到邮件,请点击<a href="/sendmail/{{email}}">重新发送</a>.
+    </span>
+{% else %}
+    <span>
+        激活邮件已经重新发送, 请检查并激活您的账户.
+    </span>
+{% endif %}
+{% endblock %}

--- a/daimaduan/templates/email/confirm.html
+++ b/daimaduan/templates/email/confirm.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}{{ title }}{% endblock %}
+{% block content %}
+{{ message }}
+{% endblock %}

--- a/daimaduan/views/errors.py
+++ b/daimaduan/views/errors.py
@@ -19,3 +19,9 @@ def error_500(error):
 @jinja2_view('error.html')
 def error_401(error):
     return {'title': u'请登录', 'message': u'请登录后再执行此操作!'}
+
+
+@error(403)
+@jinja2_view('error.html')
+def error_403(error):
+    return {'title': u'请激活email', 'message': u'请激活您在代码段注册的邮箱地址再进行操作!'}

--- a/daimaduan/views/pastes.py
+++ b/daimaduan/views/pastes.py
@@ -14,6 +14,7 @@ from daimaduan.models import Paste
 from daimaduan.models import Rate
 from daimaduan.models import Tag
 from daimaduan.utils import jsontify
+from daimaduan.utils import user_active_required
 
 
 @app.route('/', name='pastes.index')
@@ -36,6 +37,7 @@ def pastes_more():
 
 @app.get('/create', name='pastes.create')
 @login.login_required
+@user_active_required
 @jinja2_view('pastes/create.html')
 def create_get():
     form = PasteForm(data={'codes': [{'title': '', 'content': ''}]})
@@ -44,6 +46,7 @@ def create_get():
 
 @app.post('/create', name='pastes.create')
 @login.login_required
+@user_active_required
 @jinja2_view('pastes/create.html')
 def create_post():
     form = PasteForm(request.POST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ WTForms==2.0.2
 requests==1.2.3
 rauth==0.6.2
 bottle-rauth==0.1.1
+itsdangerous==0.24
+mailthon==0.1.1


### PR DESCRIPTION
修改地方：
1. config中加了发件邮箱的username和password配置。
2. 增加了confirm_token.py，用来生成临时token和从提交过来的token验证。
3. 增加了mail.py，用Mailthon来发送邮件。
4. model中增加了`is_email_confirmed`和`email_confirmed_on`field
5. 在注册成功后发送邮件。
6. 在验证链接中验证提交的token，token是根据密钥+email计算得来，验证时候是根据token和设置的过期时间来计算得到用户email，再根据email查询用户。

先review，我再修改。

后面还要做的：
1. 用户没激活之前不能发布daimaduan，应该可以查看其他公开的。
2. 注册成功发邮件那部分应该做成异步的。
3. 注册成功应该跳转到一个页面显示“注册成功，已经发emial等确认”等这样的一个提示页面。
4. 如果用户没收到email，还可以重新发送email功能。
