### PR TITLE
修改了Oauth登陆和注册的流程

### DIFF
--- a/daimaduan/forms/__init__.py
+++ b/daimaduan/forms/__init__.py
@@ -3,3 +3,4 @@ from .signin_form import SigninForm
 from .paste_form import PasteForm
 from .email_form import EmailForm
 from .password_form import PasswordForm
+from .user_info_form import UserInfoForm

--- a/daimaduan/forms/password_form.py
+++ b/daimaduan/forms/password_form.py
@@ -2,7 +2,9 @@
 from wtforms import Form
 from wtforms import PasswordField
 from wtforms.validators import InputRequired
+from wtforms.validators import EqualTo
 
 
 class PasswordForm(Form):
     password = PasswordField(u'password', validators=[InputRequired()])
+    password_confirm = PasswordField(u'密码确认', validators=[EqualTo('password', message=u'两次密码不同')])

--- a/daimaduan/forms/signup_form.py
+++ b/daimaduan/forms/signup_form.py
@@ -6,14 +6,16 @@ from wtforms import ValidationError
 from wtforms.validators import InputRequired
 from wtforms.validators import Email
 from wtforms.validators import Regexp
+from wtforms.validators import EqualTo
 from daimaduan.models import User
 
 
 class SignupForm(Form):
-    username = StringField(u'username', validators=[
+    username = StringField(u'昵称', validators=[
         InputRequired(), Regexp(r'\S{3,12}', message=u'3到12个字符，不能包含空格')])
-    email = StringField(u'email', validators=[InputRequired(), Email()])
-    password = PasswordField(u'password', validators=[InputRequired()])
+    email = StringField(u'Email', validators=[InputRequired(), Email()])
+    password = PasswordField(u'密码', validators=[InputRequired()])
+    password_confirm = PasswordField(u'密码确认', validators=[EqualTo('password', message=u'两次密码不同')])
 
     def validate_username(self, field):
         user = User.objects(username=field.data).first()
@@ -23,4 +25,4 @@ class SignupForm(Form):
     def validate_email(self, field):
         user = User.objects(email=field.data).first()
         if user is not None:
-            raise ValidationError(u'Email 已被使用')
+            raise ValidationError(u'Email已被使用')

--- a/daimaduan/models.py
+++ b/daimaduan/models.py
@@ -19,7 +19,7 @@ class BaseDocument(mongoengine.Document):
 class User(BaseDocument):
     username = mongoengine.StringField(required=True)
     email = mongoengine.StringField(required=True)
-    password = mongoengine.StringField(required=True)
+    password = mongoengine.StringField()
     salt = mongoengine.StringField()
     favourites = mongoengine.ListField(mongoengine.ReferenceField("Paste"))
     is_email_confirmed = mongoengine.BooleanField(default=False)

--- a/daimaduan/templates/shared/oauth.html
+++ b/daimaduan/templates/shared/oauth.html
@@ -1,4 +1,3 @@
-{% if not 'oauth_provider' in session %}
 <div class="pull-right">
   <span>更多选择</span>
   <a href="/oauth/google" class="btn btn-info" title="使用 Google 登录">
@@ -8,4 +7,3 @@
     <i class="fa fa-github"></i>
   </a>
 </div>
-{% endif %}


### PR DESCRIPTION
1. 用户使用Oauth登陆/注册后, 会跳到用户信息页面, email是不可修改的, username由oauth的结果中拿到, 可修改, 但是必须唯一
2. 使用普通方式注册时, 增加了密码确认字段
3. 重置密码时, 也增加了密码确认字段
4. 目前没有修改用户信息和密码的功能
