### PR TITLE
[#78]change send email to 'POST' and add csrf token.

### DIFF
--- a/daimaduan/templates/email/active.html
+++ b/daimaduan/templates/email/active.html
@@ -1,24 +1,23 @@
 {% extends 'base.html' %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
-{% if email %}
-    {% if reactive == True %}
-        <span>
-            您的邮箱没有激活，暂时不能分享代码，请激活您的email。
-        </span>
-        <br>
-    {% else %}
-        <span>
-            恭喜您, 注册成功! 我们已经向您的注册邮箱发送了激活邮件, 请检查并激活您的账户.
-        </span>
-        <br>
-    {% endif %}
+{% if reactive == True %}
     <span>
-        如果您没有收到激活邮件,请点击<a href="/sendmail/{{email}}">重新发送</a>.
+        您的邮箱没有激活，暂时不能分享代码，请激活您的email。
     </span>
+    <br>
 {% else %}
     <span>
-        激活邮件已经重新发送, 请检查并激活您的账户.
+        恭喜您, 注册成功! 我们已经向您的注册邮箱发送了激活邮件, 请检查并激活您的账户.
     </span>
+    <br>
 {% endif %}
+<span>
+    如果您没有收到激活邮件,请点击
+    <form action="/sendmail" method="POST" id="form-sendmail">
+        <input type="hidden" name="_csrf_token" value="{{ token }}">
+        <input type="hidden" name="email" value={{request.user.email}} />
+        <input type="submit" class="btn btn-primary" value="发送激活邮件" />
+    </form>
+</span>
 {% endblock %}

--- a/daimaduan/utils.py
+++ b/daimaduan/utils.py
@@ -14,6 +14,7 @@ import logging
 
 from bottle import response
 from bottle import jinja2_template
+from bottle_utils.csrf import generate_csrf_token
 from itsdangerous import URLSafeTimedSerializer
 from mailthon import email
 from mailthon.postman import Postman
@@ -144,5 +145,6 @@ def user_active_required(func):
     def wrapper(*args, **kwargs):
         if request.user.is_email_confirmed:
             return func(*args, **kwargs)
-        return jinja2_template('email/active.html', email=request.user.email, title=u"邮箱需要激活", reactive=True)
+        generate_csrf_token()
+        return jinja2_template('email/active.html', email=request.user.email, title=u"邮箱需要激活", reactive=True, token=request.csrf_token)
     return wrapper


### PR DESCRIPTION
修改地方
1. 把发送激活邮件修改为POST
2. 加入了csrf_token

测试点：
1. 注册新用户，注册成功后跳转到激活页面，这个时候显示“已经发送激活email，如果没收到，请点击重新发送”，这里的重新发送是个post表单，表单中只有csrftoken和email
2. 注册新用户没有激活email，然后点分享代码片段，这个时候user_active_required这个decorator会直接render active.html这个模板，这里的csrftoken不能获取到，我就调用generate_csrf_token()方法重新生成了一个。
