### PR TITLE
关注用户可以工作

### DIFF
--- a/daimaduan/models/base.py
+++ b/daimaduan/models/base.py
@@ -67,7 +67,7 @@ class User(BaseDocument):
         if oauth and oauth.user:
             return oauth.user
 
-    def is_followed(self, user):
+    def is_followed_by(self, user):
         return user in self.followers
 
 

--- a/daimaduan/templates/macros/users.html
+++ b/daimaduan/templates/macros/users.html
@@ -11,8 +11,8 @@
   {% include 'shared/user_panel.html' %}
 {% endmacro %}
 
-{% macro render_user_watch(request_user, user) %}
-  {% set is_watched = request_user.is_watched(user) -%}
+{% macro render_user_watch(user, current_user) %}
+  {% set is_watched = user.is_followed_by(current_user) -%}
   {% set display = is_watched | ternary('取消关注', '关注') -%}
   <div class="list-group-item">
     <button class="btn btn-info btn-xs action action-{{ is_watched | ternary('unwatch', 'watch') }}">{{ display }}</button>

--- a/daimaduan/templates/shared/user_panel.html
+++ b/daimaduan/templates/shared/user_panel.html
@@ -30,7 +30,7 @@
       喜欢的代码段
     </a>
     {% if current_user.is_authenticated and (user != current_user.user) %}
-      {{ render_user_watch(current_user.user, user) }}
+      {{ render_user_watch(user, current_user.user) }}
     {% endif %}
   </div>
 </div>

--- a/daimaduan/views/users.py
+++ b/daimaduan/views/users.py
@@ -71,15 +71,21 @@ def view_likes(username):
 
 @user_app.route('/watch', methods=['POST'])
 def watch_user():
-    user = User.objects(username=request.args.get('user')).first_or_404()
-    current_user.user.followers.append(user)
-    current_user.user.save()
-    return jsonify(watchedStatus=current_user.user.is_followed(user))
+    be_followed_user = User.objects(username=request.form.get('user')).first_or_404()
+
+    if not be_followed_user.is_followed_by(current_user.user):
+        be_followed_user.followers.append(current_user.user)
+        be_followed_user.save()
+
+    return jsonify(watchedStatus=be_followed_user.is_followed_by(current_user.user))
 
 
 @user_app.route('/unwatch', methods=['POST'])
 def unwatch_user():
-    user = User.objects(username=request.params.get('user')).first_or_404()
-    current_user.user.followers.remove(user)
-    current_user.user.save()
-    return jsonify(watchedStatus=current_user.user.is_followed(user))
+    be_followed_user = User.objects(username=request.form.get('user')).first_or_404()
+
+    if be_followed_user.is_followed_by(current_user.user):
+        be_followed_user.followers.remove(current_user.user)
+        be_followed_user.save()
+
+    return jsonify(watchedStatus=be_followed_user.is_followed_by(current_user.user))


### PR DESCRIPTION
1. 切换到flask后，在watch/unwatch中以前request.params拿不到传过来的用户了，修改了一下从request.form中获取。
2. 调整了一下关注的模型，A用户如果被B用户关注，那么则在A用户的followers中append一个B用户，感觉这样更合理吧，以后做站内通知，比如A用户发布了新代码要通知所有关注他的用户，可以直接查询A用户的follower就可以了。以前则是反过来的，会比较麻烦。
