### PR TITLE
fix logout 405 error

### DIFF
--- a/daimaduan/static/js/app.js
+++ b/daimaduan/static/js/app.js
@@ -2,8 +2,10 @@ function signoutHandler() {
   $.ajax({
     url: '/signout',
     method: 'DELETE',
-    success: function() {
-      document.location = '/';
+    success: function(data) {
+        if (data.status == 302) {
+            document.location = data.location;
+        }
     }
   });
 }

--- a/daimaduan/views/sites.py
+++ b/daimaduan/views/sites.py
@@ -4,7 +4,7 @@ import re
 
 import datetime
 from flask import abort
-from flask import Blueprint, flash, current_app, session
+from flask import Blueprint, flash, current_app, session, jsonify
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -89,10 +89,10 @@ def signin():
         return redirect(url_for('site_app.index'))
 
 
-@site_app.route('/signout', methods=['GET', 'DELETE'])
+@site_app.route('/signout', methods=['DELETE'])
 def signout_delete():
     logout_user()
-    return redirect(url_for('site_app.index'))
+    return jsonify(status=302, location="/")
 
 
 @site_app.route('/signup', methods=['GET', 'POST'])


### PR DESCRIPTION
之前signout返回的log

```
10.29.2.63 - - [18/Jan/2016 19:35:35] "DELETE /signout HTTP/1.1" 302 -
10.29.2.63 - - [18/Jan/2016 19:35:35] "DELETE / HTTP/1.1" 405 -
```

查了一下资料，当服务器将302响应发给浏览器时，浏览器并不是直接进行ajax回调处理，而是先执行302重定向——从Response Headers中读取Location信息，然后向Location中的Url发出请求，在收到这个请求的响应后才会进行ajax回调处理。

这里我觉得signout的GET方法没啥用就删了，然后让它返回一个json，这样浏览器收到的是200，然后进行ajax回调处理。
