### PR TITLE
分离dev和prod的包管理

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+cssmin==0.2.0
+scss==0.8.73
+sass==2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ flask-login==0.3.2
 Flask-Gravatar==0.4.2
 Flask-Script==2.0.5
 flask-log==0.1.0
-cssmin==0.2.0
-scss==0.8.73
-sass==2.3
 ecdsa==0.13
 Fabric==1.10.2
 flake8==2.4.1


### PR DESCRIPTION
主要是为了解决一些包其实不需要在服务器上安装的问题

本地开发的时候: `pip install -r requirements-develop.txt`
